### PR TITLE
Add support for TruffleRuby

### DIFF
--- a/lib/installer.js
+++ b/lib/installer.js
@@ -18,13 +18,21 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const core = __importStar(require("@actions/core"));
 const exec = __importStar(require("@actions/exec"));
 const tc = __importStar(require("@actions/tool-cache"));
+const os = __importStar(require("os"));
 const path = __importStar(require("path"));
 const IS_WINDOWS = process.platform === 'win32';
-function findRubyVersion(version) {
+function findRubyVersion(engineAndVersion) {
     return __awaiter(this, void 0, void 0, function* () {
-        const installDir = tc.find('Ruby', version);
+        if (!engineAndVersion.includes('-')) {
+            engineAndVersion = 'Ruby-' + engineAndVersion;
+        }
+        const [engine, version] = engineAndVersion.split('-', 2);
+        let installDir = tc.find(engine, version);
+        if (!installDir && engine == 'truffleruby') {
+            installDir = yield downloadTruffleRuby(version);
+        }
         if (!installDir) {
-            throw new Error(`Version ${version} not found`);
+            throw new Error(`Ruby version ${engine}-${version} not found`);
         }
         const toolPath = path.join(installDir, 'bin');
         if (!IS_WINDOWS) {
@@ -38,3 +46,22 @@ function findRubyVersion(version) {
     });
 }
 exports.findRubyVersion = findRubyVersion;
+function downloadTruffleRuby(version) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const arch = os.arch();
+        const platform = os.platform();
+        const convertedArch = arch == 'x64' ? 'amd64' : arch;
+        const convertedPlatform = platform == 'darwin' ? 'macos' : platform;
+        const fileName = `truffleruby-${version}-${convertedPlatform}-${convertedArch}`;
+        const baseUrl = 'https://github.com/oracle/truffleruby/releases/download';
+        const downloadUrl = `${baseUrl}/vm-${version}/${fileName}.tar.gz`;
+        let downloadPath = yield tc.downloadTool(downloadUrl);
+        let extractedPath = yield tc.extractTar(downloadPath);
+        // truffleruby extracts with a root folder that matches the fileName downloaded
+        let toolRoot = path.join(extractedPath, fileName);
+        // Run the post-install hook
+        yield exec.exec(path.join(toolRoot, 'lib/truffle/post_install_hook.sh'));
+        // Install into the local tool cache
+        return yield tc.cacheDir(toolRoot, 'truffleruby', version);
+    });
+}

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -1,15 +1,26 @@
 import * as core from '@actions/core';
 import * as exec from '@actions/exec';
 import * as tc from '@actions/tool-cache';
+import * as os from 'os';
 import * as path from 'path';
 
 const IS_WINDOWS = process.platform === 'win32';
 
-export async function findRubyVersion(version: string) {
-  const installDir: string | null = tc.find('Ruby', version);
+export async function findRubyVersion(engineAndVersion: string) {
+  if (!engineAndVersion.includes('-')) {
+    engineAndVersion = 'Ruby-' + engineAndVersion;
+  }
+
+  const [engine, version] = engineAndVersion.split('-', 2);
+
+  let installDir: string | null = tc.find(engine, version);
+
+  if (!installDir && engine == 'truffleruby') {
+    installDir = await downloadTruffleRuby(version);
+  }
 
   if (!installDir) {
-    throw new Error(`Version ${version} not found`);
+    throw new Error(`Ruby version ${engine}-${version} not found`);
   }
 
   const toolPath: string = path.join(installDir, 'bin');
@@ -23,4 +34,26 @@ export async function findRubyVersion(version: string) {
   }
 
   core.addPath(toolPath);
+}
+
+async function downloadTruffleRuby(version: string): Promise<string> {
+  const arch = os.arch();
+  const platform = os.platform();
+  const convertedArch = arch == 'x64' ? 'amd64' : arch;
+  const convertedPlatform = platform == 'darwin' ? 'macos' : platform;
+
+  const fileName = `truffleruby-${version}-${convertedPlatform}-${convertedArch}`;
+  const baseUrl = 'https://github.com/oracle/truffleruby/releases/download';
+  const downloadUrl = `${baseUrl}/vm-${version}/${fileName}.tar.gz`;
+
+  let downloadPath = await tc.downloadTool(downloadUrl);
+  let extractedPath = await tc.extractTar(downloadPath);
+  // truffleruby extracts with a root folder that matches the fileName downloaded
+  let toolRoot = path.join(extractedPath, fileName);
+
+  // Run the post-install hook
+  await exec.exec(path.join(toolRoot, 'lib/truffle/post_install_hook.sh'));
+
+  // Install into the local tool cache
+  return await tc.cacheDir(toolRoot, 'truffleruby', version);
 }


### PR DESCRIPTION
See https://github.com/actions/setup-ruby/issues/20

This now works on `ubuntu-latest`, but not yet on `macos-latest`:
Ubuntu: https://github.com/eregon/setup-ruby-test/runs/318021757
macOS: https://github.com/eregon/setup-ruby-test/runs/318021775

One thing that is still necessary is recompiling the openssl C extension against the system libssl (done in the post-install hook).

@damccorm How does the tool cache work? It does not seem to persist across runs currently with `tc.cacheDir`/`tc.find`. If it did, I think it could avoid having to run the post-install hook on every run.