### PR TITLE
Only add ruby in $PATH, do not overwrite /usr/bin/ruby

### DIFF
--- a/lib/installer.js
+++ b/lib/installer.js
@@ -16,10 +16,8 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const core = __importStar(require("@actions/core"));
-const exec = __importStar(require("@actions/exec"));
 const tc = __importStar(require("@actions/tool-cache"));
 const path = __importStar(require("path"));
-const IS_WINDOWS = process.platform === 'win32';
 function findRubyVersion(version) {
     return __awaiter(this, void 0, void 0, function* () {
         const installDir = tc.find('Ruby', version);
@@ -27,13 +25,6 @@ function findRubyVersion(version) {
             throw new Error(`Version ${version} not found`);
         }
         const toolPath = path.join(installDir, 'bin');
-        if (!IS_WINDOWS) {
-            // Ruby / Gem heavily use the '#!/usr/bin/ruby' to find ruby, so this task needs to
-            // replace that version of ruby so all the correct version of ruby gets selected
-            // replace the default
-            const dest = '/usr/bin/ruby';
-            exec.exec('sudo ln', ['-sf', path.join(toolPath, 'ruby'), dest]); // replace any existing
-        }
         core.addPath(toolPath);
     });
 }

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -1,9 +1,6 @@
 import * as core from '@actions/core';
-import * as exec from '@actions/exec';
 import * as tc from '@actions/tool-cache';
 import * as path from 'path';
-
-const IS_WINDOWS = process.platform === 'win32';
 
 export async function findRubyVersion(version: string) {
   const installDir: string | null = tc.find('Ruby', version);
@@ -13,14 +10,6 @@ export async function findRubyVersion(version: string) {
   }
 
   const toolPath: string = path.join(installDir, 'bin');
-
-  if (!IS_WINDOWS) {
-    // Ruby / Gem heavily use the '#!/usr/bin/ruby' to find ruby, so this task needs to
-    // replace that version of ruby so all the correct version of ruby gets selected
-    // replace the default
-    const dest: string = '/usr/bin/ruby';
-    exec.exec('sudo ln', ['-sf', path.join(toolPath, 'ruby'), dest]); // replace any existing
-  }
 
   core.addPath(toolPath);
 }


### PR DESCRIPTION
* Fixes https://github.com/actions/setup-ruby/issues/18
* The symlink never worked on macOS, and there was a missing `await`.
* No tool should hardcode `/usr/bin/ruby`, but instead executables
  should use `#!/usr/bin/env ruby`.
* If a specific tool needs the symlink, then it can of course be
  added as part of the steps of that CI.