### PR TITLE
Support .ruby_version

### DIFF
--- a/lib/setup-ruby.js
+++ b/lib/setup-ruby.js
@@ -16,11 +16,23 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const core = __importStar(require("@actions/core"));
+const exec = __importStar(require("@actions/exec"));
 const installer_1 = require("./installer");
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
             let version = core.getInput('version');
+            if (!version) {
+                const options = {};
+                // Ignore stderr because there is a fallback
+                // option to "ruby_version" parameter.
+                options.listeners = {
+                    stdout: (data) => {
+                        version += data.toString();
+                    }
+                };
+                yield exec.exec('cat', ['.ruby-version'], options);
+            }
             if (!version) {
                 version = core.getInput('ruby-version');
             }

--- a/src/setup-ruby.ts
+++ b/src/setup-ruby.ts
@@ -1,12 +1,30 @@
 import * as core from '@actions/core';
+import * as exec from '@actions/exec';
+import {ExecOptions} from '@actions/exec/lib/interfaces';
 import {findRubyVersion} from './installer';
 
 async function run() {
   try {
     let version = core.getInput('version');
+
     if (!version) {
       version = core.getInput('ruby-version');
     }
+
+    if (!version) {
+      const options: ExecOptions = {};
+
+      // Ignore stderr because there is a fallback
+      // option to "ruby_version" parameter.
+      options.listeners = {
+        stdout: (data: Buffer) => {
+          version += data.toString();
+        }
+      };
+
+      await exec.exec('cat', ['.ruby-version'], options);
+    }
+
     await findRubyVersion(version);
   } catch (error) {
     core.setFailed(error.message);


### PR DESCRIPTION
This PR is an implementation for  #31  by reading the target version from `.ruby-version` before using `version` parameter in workflows.