### PR TITLE
Add notes on caching to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ jobs:
         bundle exec rails test
 ```
 
+# Caching Dependencies
+
+See [actions/cache](https://github.com/actions/cache) and the [Ruby Gem cache example](https://github.com/actions/cache/blob/master/examples.md#ruby---gem).
+
 # License
 
 The scripts and documentation in this project are released under the [MIT License](LICENSE)


### PR DESCRIPTION
Follow up from https://github.com/actions/setup-ruby/issues/11, adding links to the cache action so that users can set up caching for their Ruby workflows.