### PR TITLE
Provide a link for users wanting exact or more versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ Note that a `ruby-version:` of `2.6` or `2.6.x` are equivalent.
 
 > Supports `2.4`, `2.5`, `2.6`, and `2.7`.
 
+If you want to use exact versions (e.g., `2.6.5`) of Ruby, or to use JRuby or TruffleRuby,
+please take a look at [other actions on the marketplace](https://github.com/marketplace?utf8=%E2%9C%93&type=actions&query=Setup+Ruby).
+
 # Usage
 
 See [action.yml](action.yml)


### PR DESCRIPTION
Original PR title:
> Clarify the supported versions and intended usage

* See https://github.com/actions/setup-ruby/issues/46
* See https://github.com/actions/virtual-environments/issues/281
* See https://github.com/actions/setup-ruby/issues/51
* There are many more issues about users being confused by this action, so try to be as clear as possible in the README.