### PR TITLE
workflow to validate versions

### DIFF
--- a/.github/workflows/versions.yml
+++ b/.github/workflows/versions.yml
@@ -25,5 +25,5 @@ jobs:
       with:
         ruby-version: ${{ matrix.version}}
 
-    - name: npm install
+    - name: ruby version
       run: ruby -v

--- a/.github/workflows/versions.yml
+++ b/.github/workflows/versions.yml
@@ -1,0 +1,29 @@
+name: ruby-versions
+on:
+    push:
+      branches:
+        - master
+      paths-ignore:
+        - '**.md'
+    pull_request:
+      paths-ignore:
+        - '**.md'
+jobs:
+  run:
+    name: Ruby 
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      matrix:
+        operating-system: [ubuntu-latest, windows-latest, macos-latest]
+        version: [2.4.x, 2.5.x, 2.6.x, 2.7.x]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: use-ruby ${{ matrix.version }}
+      uses: ./
+      with:
+        ruby-version: ${{ matrix.version}}
+
+    - name: npm install
+      run: ruby -v

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,5 +1,13 @@
-name: Main workflow
-on: [push]
+name: build-test
+on:
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - '**.md'
 jobs:
   run:
     name: Run
@@ -11,10 +19,10 @@ jobs:
     - name: Checkout
       uses: actions/checkout@master
 
-    - name: Set Node.js 10.x
+    - name: Set Node.js 12.x
       uses: actions/setup-node@master
       with:
-        version: 10.x
+        version: 12.x
 
     - name: npm install
       run: npm install

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # setup-ruby
 
 <p align="left">
-  <a href="https://github.com/actions/setup-ruby"><img alt="GitHub Actions status" src="https://github.com/actions/setup-ruby/workflows/Main%20workflow/badge.svg"></a>
+  <a href="https://github.com/actions/setup-ruby/actions"><img alt="test status" src="https://github.com/actions/setup-ruby/workflows/build-test/badge.svg"></a>
+
+  <a href="https://github.com/actions/setup-ruby/actions"><img alt="versions status" src="https://github.com/actions/setup-ruby/workflows/ruby-versions/badge.svg"></a>  
 </p>
 
 This action sets up a ruby environment for versions which are installed on the [Actions Virtual Environments](https://github.com/actions/virtual-environments).  Because virtual environments are updated, a workflow should only be bound to a minor versions.  


### PR DESCRIPTION
workflow in the repo to validate versions (2.4 - 2.7) at a minimum across all the latest OS versions in our hosted VM pools.