### PR TITLE
Update Postgres instructions for Rails Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ jobs:
 
     services:
       db:
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_DB: postgres
+          POSTGRES_PASSWORD: super_secret_password
+          # POSTGRES_HOST_AUTH_METHOD: trust # disables POSTGRES_PASSWORD and allows all local connections. Use with caution
         image: postgres:11
         ports: ['5432:5432']
         options: >-


### PR DESCRIPTION
The default Postgres image has changed and without any `env` variables the healthcheck will never pass.

You need to set `POSTGRES_USER` and `POSTGRES_DB`, and may choose to set either `POSTGRES_PASSWORD` or `POSTGRES_HOST_AUTH_METHOD`. If you choose to set a password, your Rails test config must specify that password. Alternatively, you can set `POSTGRES_HOST_AUTH_METHOD=trust` to allow all local connections without a password.

See https://github.com/docker-library/postgres/commit/42ce7437ee68150ee29f5272428aa4fc657dc6dc for more context