### PR TITLE
Add Licensed to verify third party dependencies

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.licenses/** -diff linguist-generated=true

--- a/.github/workflows/licensed.yml
+++ b/.github/workflows/licensed.yml
@@ -1,0 +1,20 @@
+name: Licensed
+
+on:
+  push: {branches: main}
+  pull_request: {branches: main}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    name: Check licenses
+    steps:
+      - uses: actions/checkout@v2
+      - run: npm ci
+      - name: Install licensed
+        run: |
+          cd $RUNNER_TEMP
+          curl -Lfs -o licensed.tar.gz https://github.com/github/licensed/releases/download/2.12.2/licensed-2.12.2-linux-x64.tar.gz
+          sudo tar -xzf licensed.tar.gz
+          sudo mv licensed /usr/local/bin/licensed
+      - run: licensed status

--- a/.licensed.yml
+++ b/.licensed.yml
@@ -1,0 +1,16 @@
+sources:
+  npm: true
+
+allowed:
+  - apache-2.0
+  - bsd-2-clause
+  - bsd-3-clause
+  - isc
+  - mit
+  - cc0-1.0
+  - unlicense
+  - 0bsd
+
+reviewed:
+  npm:
+  - sax

--- a/.licenses/npm/@actions/core.dep.yml
+++ b/.licenses/npm/@actions/core.dep.yml
@@ -1,0 +1,30 @@
+---
+name: "@actions/core"
+version: 1.2.2
+type: npm
+summary: Actions core lib
+homepage: https://github.com/actions/toolkit/tree/master/packages/core
+license: mit
+licenses:
+- sources: Auto-generated MIT license text
+  text: |
+    MIT License
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+notices: []

--- a/.licenses/npm/@actions/exec.dep.yml
+++ b/.licenses/npm/@actions/exec.dep.yml
@@ -1,0 +1,30 @@
+---
+name: "@actions/exec"
+version: 1.0.3
+type: npm
+summary: Actions exec lib
+homepage: https://github.com/actions/toolkit/tree/master/packages/exec
+license: mit
+licenses:
+- sources: Auto-generated MIT license text
+  text: |
+    MIT License
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+notices: []

--- a/.licenses/npm/@actions/http-client.dep.yml
+++ b/.licenses/npm/@actions/http-client.dep.yml
@@ -1,0 +1,32 @@
+---
+name: "@actions/http-client"
+version: 1.0.3
+type: npm
+summary: Actions Http Client
+homepage: https://github.com/actions/http-client#readme
+license: mit
+licenses:
+- sources: LICENSE
+  text: |
+    Actions Http Client for Node.js
+
+    Copyright (c) GitHub, Inc.
+
+    All rights reserved.
+
+    MIT License
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+    associated documentation files (the "Software"), to deal in the Software without restriction,
+    including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+    subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+    LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+    NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+notices: []

--- a/.licenses/npm/@actions/io.dep.yml
+++ b/.licenses/npm/@actions/io.dep.yml
@@ -1,0 +1,30 @@
+---
+name: "@actions/io"
+version: 1.0.2
+type: npm
+summary: Actions io lib
+homepage: https://github.com/actions/toolkit/tree/master/packages/io
+license: mit
+licenses:
+- sources: Auto-generated MIT license text
+  text: |
+    MIT License
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+notices: []

--- a/.licenses/npm/@actions/tool-cache.dep.yml
+++ b/.licenses/npm/@actions/tool-cache.dep.yml
@@ -1,0 +1,30 @@
+---
+name: "@actions/tool-cache"
+version: 1.3.1
+type: npm
+summary: Actions tool-cache lib
+homepage: https://github.com/actions/toolkit/tree/master/packages/exec
+license: mit
+licenses:
+- sources: Auto-generated MIT license text
+  text: |
+    MIT License
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+notices: []

--- a/.licenses/npm/semver.dep.yml
+++ b/.licenses/npm/semver.dep.yml
@@ -1,0 +1,26 @@
+---
+name: semver
+version: 6.3.0
+type: npm
+summary: The semantic version parser used by npm.
+homepage: https://github.com/npm/node-semver#readme
+license: isc
+licenses:
+- sources: LICENSE
+  text: |
+    The ISC License
+
+    Copyright (c) Isaac Z. Schlueter and Contributors
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose with or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+    MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+    IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+notices: []

--- a/.licenses/npm/tunnel.dep.yml
+++ b/.licenses/npm/tunnel.dep.yml
@@ -1,0 +1,35 @@
+---
+name: tunnel
+version: 0.0.6
+type: npm
+summary: Node HTTP/HTTPS Agents for tunneling proxies
+homepage: https://github.com/koichik/node-tunnel/
+license: mit
+licenses:
+- sources: LICENSE
+  text: |
+    The MIT License (MIT)
+
+    Copyright (c) 2012 Koichi Kobayashi
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+- sources: README.md
+  text: Licensed under the [MIT](https://github.com/koichik/node-tunnel/blob/master/LICENSE)
+    license.
+notices: []

--- a/.licenses/npm/uuid.dep.yml
+++ b/.licenses/npm/uuid.dep.yml
@@ -1,0 +1,39 @@
+---
+name: uuid
+version: 3.3.2
+type: npm
+summary: RFC4122 (v1, v4, and v5) UUIDs
+homepage: https://github.com/kelektiv/node-uuid#readme
+license: mit
+licenses:
+- sources: LICENSE.md
+  text: |
+    The MIT License (MIT)
+
+    Copyright (c) 2010-2016 Robert Kieffer and other contributors
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+notices:
+- sources: AUTHORS
+  text: |-
+    Robert Kieffer <robert@broofa.com>
+    Christoph Tavan <dev@tavan.de>
+    AJ ONeal <coolaj86@gmail.com>
+    Vincent Voyer <vincent@zeroload.net>
+    Roman Shtylman <shtylman@gmail.com>


### PR DESCRIPTION
GitHub has a tool called [licensed](https://github.com/github/licensed) which helps us to verify that the node modules we are using are appropriately licensed for what we are using them for. It also helps to verify that the license a node module claims to be under matches the license it.

If you were previously checking in a license in the dist file, this can replace that flow.

This PR adds:
- A workflow to check licenses on pull requests and pushes to the `main` branch
- A `licensed.yml` file used to configure `licensed`
- A number of files into the `.licenses` directory which contain our dependencies and their appropriate licenses

## How does this impact me?
- You may need to [locally install](https://github.com/github/licensed#installation) licensed and run `licensed cache` to update the dependency cache if you install a new production dependency. 
  - If `licensed cache` is unable to determine the dependency, you may need to modify the cache file yourself to put the correct license. 
- You should still verify the dependency, licensed in a tool to help, but is not a substitute for [human review of dependencies](https://github.com/github/licensed#disclaimer)
- Currently, this PR only targets production dependencies, dev dependencies are not included.
