### PR TITLE
Updating Caching link for Ruby Gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ jobs:
 
 # Caching Dependencies
 
-See [actions/cache](https://github.com/actions/cache) and the [Ruby Gem cache example](https://github.com/actions/cache/blob/master/examples.md#ruby---gem).
+See [actions/cache](https://github.com/actions/cache) and the [Ruby Bundler cache example](https://github.com/actions/cache/blob/master/examples.md#ruby---bundler).
 
 # License
 


### PR DESCRIPTION
The link to the actions/cache repo seems to be broken. I'm updating it.