### PR TITLE
Add support for Ruby 3.0

### DIFF
--- a/.github/workflows/versions.yml
+++ b/.github/workflows/versions.yml
@@ -10,12 +10,12 @@ on:
         - '**.md'
 jobs:
   run:
-    name: Ruby 
+    name: Ruby
     runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
         operating-system: [ubuntu-latest, windows-latest, macos-latest]
-        version: [2.4, 2.5.x, 2.6, 2.7.x]
+        version: [2.4, 2.5.x, 2.6, 2.7.x, 3.0]
     steps:
     - name: Checkout
       uses: actions/checkout@v2


### PR DESCRIPTION
This change attempts to add support for [Ruby 3.0][ruby3] projects.


[ruby3]: https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/
