### PR TITLE
Deprecation of actions/setup-ruby

### DIFF
--- a/.github/workflows/versions.yml
+++ b/.github/workflows/versions.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest, windows-latest, macos-latest]
-        version: [2.4, 2.5.x, 2.6, 2.7.x]
+        version: [2.5.x, 2.6, 2.7.x]
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -89,4 +89,3 @@ typings/
 
 # DynamoDB Local files
 .dynamodb/
-dist/index.js

--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,4 @@ typings/
 
 # DynamoDB Local files
 .dynamodb/
+dist/index.js

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <a href="https://github.com/actions/setup-ruby/actions"><img alt="versions status" src="https://github.com/actions/setup-ruby/workflows/ruby-versions/badge.svg"></a>  
 </p>
 
-**Please note: This action is deprecated and should no longer be used. The team at GitHub has ceased making and accepting code contributions or maintaining issues tracker. Please, migrate your workflows to the [ruby/setup-ruby](https://github.com/ruby/setup-ruby) action, which is being actively maintained by the official Ruby organization.**
+**Please note: This action is deprecated and should no longer be used. The team at GitHub has ceased making and accepting code contributions or maintaining issues tracker. Please, migrate your workflows to the [ruby/setup-ruby](https://github.com/ruby/setup-ruby), which is being actively maintained by the official Ruby organization.**
 
 
 This action sets up a ruby environment for versions which are installed on the [Actions Virtual Environments](https://github.com/actions/virtual-environments).

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
   <a href="https://github.com/actions/setup-ruby/actions"><img alt="versions status" src="https://github.com/actions/setup-ruby/workflows/ruby-versions/badge.svg"></a>  
 </p>
 
+**Please note: This repository is currently unmaintained by a team of developers at GitHub, we are not going to be updating issues or pull requests on this repository. Please, migrate your workflows to [ruby/setup-ruby](https://github.com/ruby/setup-ruby) by official [Ruby community](https://www.ruby-lang.org/en/).**
+
 This action sets up a ruby environment for versions which are installed on the [Actions Virtual Environments](https://github.com/actions/virtual-environments).
 
 Virtual environments contain only one Ruby version within a 'major.minor' release, and are updated with new releases.  Hence, a workflow should only be bound to minor versions.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
   <a href="https://github.com/actions/setup-ruby/actions"><img alt="versions status" src="https://github.com/actions/setup-ruby/workflows/ruby-versions/badge.svg"></a>  
 </p>
 
-**Please note: This repository is currently unmaintained by a team of developers at GitHub, we are not going to be updating issues or pull requests on this repository. Please, migrate your workflows to [ruby/setup-ruby](https://github.com/ruby/setup-ruby) by official [Ruby community](https://www.ruby-lang.org/en/).**
+**Please note: This action is deprecated and should no longer be used. The team at GitHub has ceased making and accepting code contributions or maintaining issues tracker. Please, migrate your workflows to the [ruby/setup-ruby](https://github.com/ruby/setup-ruby) action, which is being actively maintained by the official Ruby organization.**
+
 
 This action sets up a ruby environment for versions which are installed on the [Actions Virtual Environments](https://github.com/actions/virtual-environments).
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -1331,8 +1331,8 @@ function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
             core.info('------------------------');
-            core.info('NOTE: this action is deprecated and will not be maintained in future by GitHub engineers.');
-            core.info('Please, migrate to https://github.com/ruby/setup-ruby from official Ruby community.');
+            core.info('NOTE: This action is deprecated and is no longer maintained.');
+            core.info('Please, migrate to https://github.com/ruby/setup-ruby action, which is being actively maintained.');
             core.info('------------------------');
             let versionSpec = core.getInput('ruby-version', { required: true });
             if (!versionSpec) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -1332,7 +1332,7 @@ function run() {
         try {
             core.info('------------------------');
             core.info('NOTE: This action is deprecated and is no longer maintained.');
-            core.info('Please, migrate to https://github.com/ruby/setup-ruby action, which is being actively maintained.');
+            core.info('Please, migrate to https://github.com/ruby/setup-ruby, which is being actively maintained.');
             core.info('------------------------');
             let versionSpec = core.getInput('ruby-version', { required: true });
             if (!versionSpec) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -1330,6 +1330,10 @@ const cache = __importStar(__webpack_require__(365));
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
+            core.info('------------------------');
+            core.info('NOTE: this action is deprecated and will not be maintained in future by GitHub engineers.');
+            core.info('Please, migrate to https://github.com/ruby/setup-ruby from official Ruby community.');
+            core.info('------------------------');
             let versionSpec = core.getInput('ruby-version', { required: true });
             if (!versionSpec) {
                 // deprecated

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,11 @@ import * as cache from './cache';
 
 export async function run() {
   try {
-    core.info('Please note: this action is deprecated and will not be maintained in future by GitHub engineers. Please, migrate to https://github.com/ruby/setup-ruby from official Ruby community.');
+    core.info('------------------------');
+    core.info('NOTE: this action is deprecated and will not be maintained in future by GitHub engineers.');
+    core.info('Please, migrate to https://github.com/ruby/setup-ruby from official Ruby community.');
+    core.info('------------------------');
+
     let versionSpec = core.getInput('ruby-version', {required: true});
     if (!versionSpec) {
       // deprecated

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,11 +4,9 @@ import * as cache from './cache';
 export async function run() {
   try {
     core.info('------------------------');
+    core.info('NOTE: This action is deprecated and is no longer maintained.');
     core.info(
-      'NOTE: this action is deprecated and will not be maintained in future by GitHub engineers.'
-    );
-    core.info(
-      'Please, migrate to https://github.com/ruby/setup-ruby from official Ruby community.'
+      'Please, migrate to https://github.com/ruby/setup-ruby action, which is being actively maintained.'
     );
     core.info('------------------------');
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,7 @@ export async function run() {
     core.info('------------------------');
     core.info('NOTE: This action is deprecated and is no longer maintained.');
     core.info(
-      'Please, migrate to https://github.com/ruby/setup-ruby action, which is being actively maintained.'
+      'Please, migrate to https://github.com/ruby/setup-ruby, which is being actively maintained.'
     );
     core.info('------------------------');
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import * as cache from './cache';
 
 export async function run() {
   try {
+    core.info('Please note: this action is deprecated and will not be maintained in future by GitHub engineers. Please, migrate to https://github.com/ruby/setup-ruby from official Ruby community.');
     let versionSpec = core.getInput('ruby-version', {required: true});
     if (!versionSpec) {
       // deprecated

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,8 +4,12 @@ import * as cache from './cache';
 export async function run() {
   try {
     core.info('------------------------');
-    core.info('NOTE: this action is deprecated and will not be maintained in future by GitHub engineers.');
-    core.info('Please, migrate to https://github.com/ruby/setup-ruby from official Ruby community.');
+    core.info(
+      'NOTE: this action is deprecated and will not be maintained in future by GitHub engineers.'
+    );
+    core.info(
+      'Please, migrate to https://github.com/ruby/setup-ruby from official Ruby community.'
+    );
     core.info('------------------------');
 
     let versionSpec = core.getInput('ruby-version', {required: true});


### PR DESCRIPTION
We are now safe to deprecate actions/setup-ruby after GitHub-hosted runners were moved to official pre-cached binaries. 
We encourage customers to move to ruby/setup-ruby actions.